### PR TITLE
Adding Labels to Fleets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   </parent>
   <groupId>com.amazon.jenkins.fleet</groupId>
   <artifactId>ec2-fleet</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>EC2 Fleet Jenkins Plugin</name>

--- a/src/main/java/com/amazon/jenkins/ec2fleet/CloudNanny.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/CloudNanny.java
@@ -10,6 +10,8 @@ import jenkins.model.Jenkins;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * User: cyberax
@@ -20,21 +22,26 @@ import java.util.List;
 @SuppressWarnings("unused")
 public class CloudNanny extends PeriodicWork
 {
+    private static final Logger LOGGER = Logger.getLogger(CloudNanny.class.getName());
+
     @Override public long getRecurrencePeriod() {
         return 10000L;
     }
 
     @Override protected void doRun() throws Exception {
+
         // Trigger reprovisioning as well
         Jenkins.getInstance().unlabeledNodeProvisioner.suggestReviewNow();
 
         final List<FleetStateStats> stats = new ArrayList<FleetStateStats>();
         for(final Cloud cloud : Jenkins.getInstance().clouds) {
+
             if (!(cloud instanceof EC2Cloud))
                 continue;
 
             // Update the cluster states
             final EC2Cloud fleetCloud =(EC2Cloud) cloud;
+            LOGGER.log(Level.INFO, "Checking cloud: " + fleetCloud.getLabel() );
             stats.add(fleetCloud.updateStatus());
         }
 

--- a/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
@@ -1,7 +1,10 @@
 package com.amazon.jenkins.ec2fleet;
 
 import hudson.model.Computer;
+import hudson.model.Node;
 import hudson.slaves.RetentionStrategy;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * User: cyberax
@@ -13,18 +16,43 @@ public class IdleRetentionStrategy extends RetentionStrategy<Computer>
     private final int maxIdleMinutes;
     private final EC2Cloud parent;
 
+    private static final Logger LOGGER = Logger.getLogger(IdleRetentionStrategy.class.getName());
+
     public IdleRetentionStrategy(final int maxIdleMinutes, final EC2Cloud parent) {
         this.maxIdleMinutes = maxIdleMinutes;
         this.parent = parent;
+        LOGGER.log(Level.INFO, "Idle Retention initiated");
     }
 
     protected boolean isIdleForTooLong(final Computer c) {
+        long age = System.currentTimeMillis()-c.getIdleStartMilliseconds();
+        long maxAge = maxIdleMinutes*60*1000;
+        LOGGER.log(Level.FINE, "Instance: " + c.getDisplayName() + " Age: " + age + " Max Age:" + maxAge);
         return System.currentTimeMillis()-c.getIdleStartMilliseconds() > (maxIdleMinutes*60*1000);
     }
 
     @Override public long check(final Computer c) {
-        if (isIdleForTooLong(c))
-            parent.terminateInstance(c.getName());
+        if (isIdleForTooLong(c)){
+            // Split labels and find instance ID
+            Node compNode = c.getNode();
+            if (compNode.equals(null)){
+                return 0;
+            }
+            
+            String nodeId = null;
+            for(String str: c.getNode().getLabelString().split(" ")){
+                if(str.startsWith("i-")){
+                    nodeId = str;
+                }
+            }
+             
+            if (nodeId.equals(null)){
+                LOGGER.log(Level.INFO, "Node " + c.getName(), " does not have proper labels");
+                return 0;
+            }
+            LOGGER.log(Level.INFO, "Terminating Fleet instance: " + nodeId);
+            parent.terminateInstance(nodeId);
+        }
 
         return 1;
     }

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2Cloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2Cloud/config.jelly
@@ -25,6 +25,9 @@
     <f:entry title="${%Spot Fleet}" field="fleet">
       <f:select/>
     </f:entry>
+    <f:entry title="${%Label}" field="label">
+      <f:textbox />
+    </f:entry>
     <f:entry title="${%Max Idle Minutes Before Scaledown}" field="idleMinutes">
       <f:number clazz="positive-number"/>
     </f:entry>


### PR DESCRIPTION
Related Issue: https://github.com/awslabs/ec2-spot-jenkins-plugin/issues/1
### Problem

We run multiple fleets for multiple instance sizes, example: smaller instances for quick unit tests and large instances for integration.

Running multiple fleets doesn't scale properly. The first fleet in the list receives all the scale up and down events ignoring the other fleets.
### Solution

Add labels to fleets so the correct fleet can be selected for scaling up.
### Testing
1. Apply plugin
2. Change swarm command on userdata to include the instanceID in the label
3. Create two fleet plugins, set label in UI
4. Create a low demand for one tag, and high demand for other job by scheduling fake workers
5. Verify fleets get scaled according
6. After all jobs have been complete fleets are scaled back to 1
### Considerations
- The original setup is to use the instance ID as the name of the node. This info is then used for scaling down and term the node. This didn't work out very well and wasn't documented anywhere.
- To use this PR you must assign the instance ID to as a label in Jenkins. This allows the display name of the node to be customized without breaking the plugin.
- Very little logging was included which made discovering the node name must be instance ID fun to troubleshoot. I added some logging of important events and more detailed logging as FINE level.
