### PR TITLE
Scale executors by LaunchSpecification weight

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/FleetStateStats.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/FleetStateStats.java
@@ -6,14 +6,16 @@ import com.amazonaws.services.ec2.model.DescribeSpotFleetInstancesRequest;
 import com.amazonaws.services.ec2.model.DescribeSpotFleetInstancesResult;
 import com.amazonaws.services.ec2.model.DescribeSpotFleetRequestsRequest;
 import com.amazonaws.services.ec2.model.DescribeSpotFleetRequestsResult;
+import com.amazonaws.services.ec2.model.SpotFleetLaunchSpecification;
 import com.amazonaws.services.ec2.model.SpotFleetRequestConfig;
+import com.amazonaws.services.ec2.model.SpotFleetRequestConfigData;
 
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -24,22 +26,26 @@ import java.util.Set;
 @SuppressWarnings("unused")
 public final class FleetStateStats
 {
+    private static final double DEFAULT_WEIGHT = 1.0;
     private @Nonnull final String fleetId;
     private @Nonnegative final int numActive;
     private @Nonnegative final int numDesired;
     private @Nonnull final String state;
     private @Nonnull final Set<String> instances;
+    private @Nonnull final Map<String,Double> instanceTypeWeights;
     private @Nonnull final String label;
 
     public FleetStateStats(final @Nonnull String fleetId,
                            final int numDesired, final @Nonnull String state,
                            final @Nonnull Set<String> instances,
+                           final @Nonnull Map<String, Double> instanceTypeWeights,
                            final @Nonnull String label) {
         this.fleetId=fleetId;
         this.numActive=instances.size();
         this.numDesired=numDesired;
         this.state=state;
         this.instances=instances;
+        this.instanceTypeWeights=instanceTypeWeights;
         this.label=label;
     }
 
@@ -67,6 +73,11 @@ public final class FleetStateStats
         return label;
     }
 
+    public Double getInstanceTypeWeight(String instanceType)  {
+        Double instanceTypeWeight = instanceTypeWeights.get(instanceType);
+        return instanceTypeWeight == null ? DEFAULT_WEIGHT : instanceTypeWeight;
+    }
+
     public static FleetStateStats readClusterState(final AmazonEC2 ec2, final String fleetId, final String label)
     {
         String token = null;
@@ -90,10 +101,24 @@ public final class FleetStateStats
             throw new IllegalStateException("Fleet "+fleetId+" can't be described");
 
         final SpotFleetRequestConfig fleetConfig=fleet.getSpotFleetRequestConfigs().get(0);
+        final SpotFleetRequestConfigData fleetRequestConfig = fleetConfig.getSpotFleetRequestConfig();
+
+        // Index configured instance types by weight:
+        final Map<String, Double> instanceTypeWeight = new HashMap<String, Double>();
+        for (SpotFleetLaunchSpecification launchSpecification : fleetRequestConfig.getLaunchSpecifications()) {
+            final String instanceType = launchSpecification.getInstanceType();
+            final Double instanceWeight = launchSpecification.getWeightedCapacity();
+            final Double existingWeight = instanceTypeWeight.get(instanceType);
+            if (existingWeight!=null && existingWeight > instanceWeight) {
+                continue;
+            }
+            instanceTypeWeight.put(instanceType, instanceWeight);
+        }
 
         return new FleetStateStats(fleetId,
-                fleetConfig.getSpotFleetRequestConfig().getTargetCapacity(),
+                fleetRequestConfig.getTargetCapacity(),
                 fleetConfig.getSpotFleetRequestState(), instances,
+                Collections.unmodifiableMap(instanceTypeWeight),
                 label);
     }
 }

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -42,6 +42,9 @@
     <f:entry title="${%Number of Executors}" field="numExecutors">
       <f:textbox clazz="required positive-number" default="1" />
     </f:entry>
+    <f:entry title="${%Scale Executors by Weight}" field="scaleExecutorsByWeight">
+      <f:checkbox />
+    </f:entry>
     <f:entry title="${%Max Idle Minutes Before Scaledown}" field="idleMinutes">
       <f:number clazz="positive-number"/>
     </f:entry>


### PR DESCRIPTION
This works nicely with a SpotFleet weighted by vCPU count (easy in the
management console).